### PR TITLE
Issue/22 robust flight telemetry

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "lib/gsl"]
 	path = lib/gsl
 	url = https://github.com/ampl/gsl.git
+[submodule "lib/fmt"]
+	path = lib/fmt
+	url = https://github.com/fmtlib/fmt.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,8 @@ project(hpr-sim DESCRIPTION "High Power Rocktry - Flight Simulation"
 
 # BUILD SETTINGS
 
-set(CMAKE_POSITION_INDEPENDENT_CODE ON) # For shared libs; delete in future if unnecessary
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # GNU GSL - minimize build
 set(NO_AMPL_BINDINGS  true)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ set(BUILDLIBS "interpolation"
 
 add_subdirectory(lib/pybind11) # Provides CMake helper functions
 add_subdirectory(lib/gsl)      # Provides math utilities
+add_subdirectory(lib/fmt)      # Provides stdio alternative
 add_subdirectory(src)          # CPP modules via pybind11
 
 # lib/eigen is header-only, does not need to be a compilation target

--- a/config/config_input.yml
+++ b/config/config_input.yml
@@ -49,18 +49,10 @@ exec:
         min: 0
         max: .inf
 flight:
-    timeFlight:
-        type: float
-        quantity: time
-        unit: s
-        min: 0.0
-        max: .inf
-    timeStep:
-        type: float
-        quantity: time
-        unit: s
-        min: 0.0
-        max: .inf
+    output:
+        type: str
+        isPath: false
+        valid: [text, binary, none]
     precision:
         type: int
         quantity: null

--- a/config/config_input.yml
+++ b/config/config_input.yml
@@ -26,7 +26,7 @@
 #     None
 ---
 exec:
-    mode:
+    mcMode:
         type: str
         isPath: false
         valid: [nominal, montecarlo]
@@ -42,6 +42,10 @@ exec:
         unit: null
         min: 0
         max: .inf
+    procMode:
+        type: str
+        isPath: false
+        valid: [serial, parallel]
     numProc:
         type: int
         quantity: null
@@ -49,7 +53,7 @@ exec:
         min: 0
         max: .inf
 flight:
-    output:
+    telemMode:
         type: str
         isPath: false
         valid: [text, binary, none]

--- a/input/unit_test.yml
+++ b/input/unit_test.yml
@@ -11,8 +11,7 @@ exec:
     numMC: 5
     numProc: 4
 flight:
-    timeFlight: 100.0
-    timeStep: 0.01
+    output: text
     precision: 3
 engine:
     inputPath: input/AeroTech_J450DM.eng

--- a/input/unit_test.yml
+++ b/input/unit_test.yml
@@ -6,12 +6,13 @@ const:
     pi: 3.141592653589793
 #-----------------------------------------------------------------------------#
 exec:
-    mode: montecarlo
+    mcMode: montecarlo
     seed: 0
     numMC: 5
+    procMode: parallel
     numProc: 4
 flight:
-    output: text
+    telemMode: text
     precision: 3
 engine:
     inputPath: input/AeroTech_J450DM.eng

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,7 @@ set(HDR "./model/model.h")
 
 set(DEP util_model
         gsl
+        fmt
         )
 
 pybind11_add_module(model MODULE ${SRC} ${HDR})

--- a/src/exec/exec.py
+++ b/src/exec/exec.py
@@ -1,6 +1,7 @@
 # System modules
 import sys
 import os
+import shutil
 import pathlib
 import copy
 import multiprocessing as mp
@@ -107,8 +108,10 @@ def exec(inputPath, outputPath):
     inputName   = pathlib.Path(inputPath).stem
     outputPath2 = pathlib.Path(outputPath) / inputName
 
-    if not os.path.exists(outputPath2):
-        os.mkdir(outputPath2)
+    if os.path.exists(outputPath2):
+        shutil.rmtree(outputPath2)
+
+    os.mkdir(outputPath2)
 
     # Validate telemetry output fields
     telemInvalid = set(configOutput["telem"]) - set(model.Flight.telemFieldsDefault)
@@ -246,22 +249,20 @@ def run_sim(simInput, simConfig, simData, iRun):
 
     telemMode = simInput["flight"]["output"]["value"]
     nPrec     = simInput["flight"]["precision"]["value"]
+
+    # Setup run output folder
     outputPath3 = simConfig.outputPath2 / f"run{iRun}"
+    os.mkdir(outputPath3)
+
     flight.init(telemMode, nPrec, str(outputPath3))
 
     # Execute flight
     flight.update()
-    write_output(simInput, simConfig, iRun, flight)
+    write_output(simInput, simConfig, outputPath3, flight)
 
 #------------------------------------------------------------------------------#
 
-def write_output(simInput, simConfig, iRun, flight):
-
-    # Setup run output folder
-    outputPath3 = simConfig.outputPath2 / f"run{iRun}"
-
-    if not os.path.exists(outputPath3):
-        os.mkdir(outputPath3)
+def write_output(simInput, simConfig, outputPath3, flight):
 
     # Write input *.yml
     # Archives montecarlo draw for run recreation

--- a/src/exec/exec.py
+++ b/src/exec/exec.py
@@ -191,7 +191,7 @@ def exec(inputPath, outputPath):
                 pool.join()
 
         # Write summary *.yml
-        write_summary(simConfig.outputPath2 / "summary.yml", simInput["flight"]["precision"]["value"])
+        write_mc_summary(simConfig.outputPath2 / "summary.yml", simInput["flight"]["precision"]["value"])
 
 #------------------------------------------------------------------------------#
 
@@ -269,11 +269,11 @@ def run_sim(simInput, simConfig, simData, iRun):
 
     # Execute flight
     flight.update()
-    write_output(simInput, simConfig, outputPath3, flight)
+    write_mc_input(simInput, simConfig, outputPath3)
 
 #------------------------------------------------------------------------------#
 
-def write_output(simInput, simConfig, outputPath3, flight):
+def write_mc_input(simInput, simConfig, outputPath3):
 
     # Write input *.yml
     # Archives montecarlo draw for run recreation
@@ -301,13 +301,9 @@ def write_output(simInput, simConfig, outputPath3, flight):
     with open(str(outputInput), 'w') as file:
         yaml.dump(simInput, file, sort_keys=False, indent=4)
 
-    # Write statistics *.yml
-    outputStats = outputPath3 / "stats.yml"
-    flight.write_stats(str(outputStats))
-
 #------------------------------------------------------------------------------#
 
-def write_summary(filePathOut, nPrec):
+def write_mc_summary(filePathOut, nPrec):
 
     dir = pathlib.Path(filePathOut).parent
     subdirs = [subdir for subdir in dir.iterdir() if subdir.is_dir()]

--- a/src/exec/exec.py
+++ b/src/exec/exec.py
@@ -244,11 +244,10 @@ def run_sim(simInput, simConfig, simData, iRun):
 
     flight.set_telem(simConfig.output["telem"], simConfig.output["telemUnits"])
 
-    t0    = 0.0
-    dt    = simInput["flight"]["timeStep"]["value"]
-    tf    = simInput["flight"]["timeFlight"]["value"]
-    nPrec = simInput["flight"]["precision"]["value"]
-    flight.init(t0, dt, tf, nPrec)
+    telemMode = simInput["flight"]["output"]["value"]
+    nPrec     = simInput["flight"]["precision"]["value"]
+    outputPath3 = simConfig.outputPath2 / f"run{iRun}"
+    flight.init(telemMode, nPrec, str(outputPath3))
 
     # Execute flight
     flight.update()
@@ -289,10 +288,6 @@ def write_output(simInput, simConfig, iRun, flight):
 
     with open(str(outputInput), 'w') as file:
         yaml.dump(simInput, file, sort_keys=False, indent=4)
-
-    # Write telemetry *.csv
-    outputTelem = outputPath3 / "telem.csv"
-    flight.write_telem(str(outputTelem))
 
     # Write statistics *.yml
     outputStats = outputPath3 / "stats.yml"

--- a/src/exec/exec.py
+++ b/src/exec/exec.py
@@ -283,11 +283,11 @@ def run_sim(simInput, simConfig, simData, iRun):
 
     # Execute flight
     flight.update()
-    write_mc_input(simInput, simConfig, outputPath3)
+    write_input(simInput, simConfig, iRun)
 
 #------------------------------------------------------------------------------#
 
-def write_mc_input(simInput, simConfig, outputPath3):
+def write_input(simInput, simConfig, iRun):
 
     # Write input *.yml
     # Archives montecarlo draw for run recreation
@@ -310,10 +310,23 @@ def write_mc_input(simInput, simConfig, outputPath3):
                     value = util_unit.convert(value, quantity, "default", unit)
                     simInput[group][param]["value"] = value
 
+    outputPath3 = simConfig.outputPath2 / f"run{iRun}"
     outputInput = outputPath3 / "input.yml"
 
     with open(str(outputInput), 'w') as file:
-        yaml.dump(simInput, file, sort_keys=False, indent=4)
+
+        numMC = simInput["exec"]["numMC"]["value"]
+
+        # Make header string for metadata
+        metaStr0 = f"# {simConfig.metadata.timeStamp}\n"
+        metaStr1 = f"# hpr-sim v{simConfig.metadata.version}\n"
+        metaStr2 = f"# Input: {simConfig.inputPath}\n"
+        metaStr3 = f"# Run: {iRun}/{numMC}"
+        metaStr  = metaStr0 + metaStr1 + metaStr2 + metaStr3
+
+        file.write(f"{metaStr}\n")
+
+        yaml.dump(simInput, file, indent=4, explicit_start=True, explicit_end=True, sort_keys=False)
 
 #------------------------------------------------------------------------------#
 

--- a/src/model/flight.cpp
+++ b/src/model/flight.cpp
@@ -82,8 +82,12 @@ void Flight::update()
 
     for (const auto& field : telemFields)
     {
-        stateTelemMin[field]   = *state->at(field);
+
+        stateTelem[field][iTelem] = static_cast<float>(*state->at(field));
+
+        stateTelemMin[field] = *state->at(field);
         stateTelemMax[field] = *state->at(field);
+
     }
 
     iStep += 1;
@@ -101,15 +105,15 @@ void Flight::update()
 
         iTelem = iStep % N_TELEM_ARRAY; // Index wraps from [0, N_TELEM_ARRAY]
 
-        if (iTelem == 0)
-        {
-            write_telem(iTelem);
-            update_stats(iTelem);
-        }
-
         for (const auto& field : telemFields)
         {
            stateTelem[field][iTelem] = static_cast<float>(*state->at(field));
+        }
+
+        if (iTelem == (N_TELEM_ARRAY - 1))
+        {
+            write_telem(iTelem);
+            update_stats(iTelem);
         }
 
         iStep += 1;
@@ -300,7 +304,7 @@ void Flight::write_telem_text(const int& iTelem) // TODO: maybe return bool for 
 
     std::string strOut;
 
-    for (int iStep = 0; iStep < iTelem; iStep++)
+    for (int iStep = 0; iStep < (iTelem + 1); iStep++)
     {
 
         oss.str("");

--- a/src/model/flight.cpp
+++ b/src/model/flight.cpp
@@ -16,7 +16,7 @@
 
 //---------------------------------------------------------------------------//
 
-void Flight::init(const std::string& telemModeIn,  const int& nPrecIn, const std::string& outputDirIn)
+void Flight::init(const std::string& telemModeIn,  const int& nPrecIn, const std::string& outputDirIn, const std::string& metaStrIn)
 {
 
     // Solver setup
@@ -41,6 +41,7 @@ void Flight::init(const std::string& telemModeIn,  const int& nPrecIn, const std
     telemMode = telemModeIn;
     nPrec     = nPrecIn;
     outputDir = outputDirIn;
+    metaStr   = metaStrIn;
 
     init_telem();
 
@@ -307,6 +308,7 @@ void Flight::init_telem_text(const std::string& filePath)
     auto out = fmt::memory_buffer();
     const char* delim = ",";
 
+    fmt::format_to(std::back_inserter(out), "{}\n", metaStr);
     fmt::format_to(std::back_inserter(out), "{}\n", fmt::join(telemFields, delim));
     fmt::format_to(std::back_inserter(out), "{}\n", fmt::join(telemUnits , delim));
     fmt::print(telemFile, fmt::to_string(out));
@@ -409,6 +411,7 @@ void Flight::write_stats() // TODO: maybe return bool for success/error status?
     const std::string tab = "    "; // 4 spaces
 
     // Document start
+    fmt::format_to(std::back_inserter(out), "{}\n", metaStr);
     fmt::format_to(std::back_inserter(out), "---\n");
 
     std::string field;

--- a/src/model/flight.cpp
+++ b/src/model/flight.cpp
@@ -85,7 +85,7 @@ void Flight::update()
     for (const auto& field : telemFields)
     {
 
-        stateTelem[field][iTelem] = static_cast<float>(*state->at(field));
+        stateTelem[field][iTelem] = *state->at(field);
 
         stateTelemMin[field] = *state->at(field);
         stateTelemMax[field] = *state->at(field);
@@ -109,7 +109,7 @@ void Flight::update()
 
         for (const auto& field : telemFields)
         {
-           stateTelem[field][iTelem] = static_cast<float>(*state->at(field));
+           stateTelem[field][iTelem] = *state->at(field);
         }
 
         if (iTelem == (N_TELEM_ARRAY - 1))

--- a/src/model/model.h
+++ b/src/model/model.h
@@ -350,6 +350,7 @@ class Flight : public Model
         void write_telem(const int& iTelem);
         void write_telem_text(const int& iTelem);
         void write_telem_binary(const int& iTelem);
+        void telem_interp(const int& iTelem);
         void update_stats(const int& iTelem);
 
         std::vector<std::string> telemFields;

--- a/src/model/model.h
+++ b/src/model/model.h
@@ -1,13 +1,12 @@
 #pragma once
 
 // System libraries
+#include <cstdio>
 #include <string>
 #include <vector>
 #include <set>
 #include <map>
 #include <memory>
-#include <iostream>
-#include <fstream>
 
 // External libraries
 #include "pybind11/pybind11.h"
@@ -356,12 +355,14 @@ class Flight : public Model
         std::vector<std::string> telemFields;
         std::vector<std::string> telemUnits;
 
+        int nTelemFields;
+
         telemArrayMap stateTelem;
         telemMap      stateTelemMin;
         telemMap      stateTelemMax;
 
         std::string   telemMode;
-        std::ofstream telemStream;
+        std::FILE*    telemFile;
 
         // State variables
 

--- a/src/model/model.h
+++ b/src/model/model.h
@@ -324,7 +324,7 @@ class Flight : public Model
 
     public:
 
-        void init(const std::string& telemModeIn,  const int& nPrecIn, const std::string& outputDirIn);
+        void init(const std::string& telemModeIn, const int& nPrecIn, const std::string& outputDirIn, const std::string& metaStrIn);
         void set_state_fields() override;
         void update() override;
 
@@ -363,6 +363,8 @@ class Flight : public Model
 
         std::string   telemMode;
         std::FILE*    telemFile;
+
+        std::string metaStr;
 
         // State variables
 

--- a/src/model/model.h
+++ b/src/model/model.h
@@ -29,17 +29,14 @@
 namespace py = pybind11;
 
 // Type aliases
-using stateMap      = std::map<std::string, double*>;
+using stateMap      = std::unordered_map<std::string, double*>;
 using stateMapPtr   = std::shared_ptr<stateMap>;
 
-using telemMap      = std::map<std::string, double>;
+using telemMap      = std::unordered_map<std::string, double>;
 using telemArray    = std::array<double, N_TELEM_ARRAY>;
-using telemArrayMap = std::map<std::string, telemArray>;
+using telemArrayMap = std::unordered_map<std::string, telemArray>;
 
 using numpyArray    = py::array_t<double, py::array::c_style | py::array::forcecast>;
-
-// TODO: consider replacing std::map w/ std::unordered_map for performance
-// Performance vs. memory usage?
 
 //---------------------------------------------------------------------------//
 

--- a/src/model/model.h
+++ b/src/model/model.h
@@ -324,12 +324,11 @@ class Flight : public Model
 
     public:
 
-        void init(const std::string& telemModeIn,  const int& nPrecIn, const std::string& outputDir);
+        void init(const std::string& telemModeIn,  const int& nPrecIn, const std::string& outputDirIn);
         void set_state_fields() override;
         void update() override;
 
         void set_telem(const std::vector<std::string>& telemFieldsInit, const std::vector<std::string>& telemUnitsInit);
-        void write_stats(const std::string& filePath);
 
         ~Flight(); // Destructor
 
@@ -341,14 +340,17 @@ class Flight : public Model
     private:
 
         // Telemetry
-        void init_telem(const std::string& outputDir);
+        void init_telem();
         void init_telem_text(const std::string& filePath);
         void init_telem_binary(const std::string& filePath);
-        void write_telem(const int& iTelem);
-        void write_telem_text(const int& iTelem);
-        void write_telem_binary(const int& iTelem);
-        void telem_interp(const int& iTelem);
-        void update_stats(const int& iTelem);
+        void write_telem();
+        void write_telem_text();
+        void write_telem_binary();
+        void telem_interp();
+        void update_stats();
+        void write_stats();
+
+        std::string outputDir;
 
         std::vector<std::string> telemFields;
         std::vector<std::string> telemUnits;
@@ -369,9 +371,9 @@ class Flight : public Model
         // Miscellaneous
         double dt;
         int    nPrec;
+        int    iTelem;
 
         bool   flightTerm{false};
-        int    flightTermStep;
 
         // TODO: create "phase" structure to capture all flags
 

--- a/src/model/model_bind.cpp
+++ b/src/model/model_bind.cpp
@@ -137,7 +137,6 @@ void bind_Flight(py::module_ &m)
         .def_readonly_static("telemFieldsDefault", &Flight::telemFieldsDefault)
         .def_readonly_static("telemUnitsDefault", &Flight::telemUnitsDefault)
         .def("set_telem", &Flight::set_telem)
-        .def("write_telem", &Flight::write_telem)
         .def("write_stats", &Flight::write_stats);
 
 }

--- a/src/model/model_bind.cpp
+++ b/src/model/model_bind.cpp
@@ -136,7 +136,6 @@ void bind_Flight(py::module_ &m)
         .def("init", &Flight::init)
         .def_readonly_static("telemFieldsDefault", &Flight::telemFieldsDefault)
         .def_readonly_static("telemUnitsDefault", &Flight::telemUnitsDefault)
-        .def("set_telem", &Flight::set_telem)
-        .def("write_stats", &Flight::write_stats);
+        .def("set_telem", &Flight::set_telem);
 
 }

--- a/src/preproc/preproc_engine.py
+++ b/src/preproc/preproc_engine.py
@@ -94,7 +94,7 @@ def load_eng(inputPath):
     thrustNorm = thrust / thrust.max()
     alpha      = propMass / np.trapz(thrustNorm, time) # Scaling factor
     massFlow   = alpha * thrustNorm
-    mass       = totalMass - integrate.cumtrapz(massFlow, time)
+    mass       = totalMass - integrate.cumulative_trapezoid(massFlow, time)
     mass       = np.insert(mass, 0, totalMass) # t=0 mass @ totalMass
 
     return time, thrust, mass


### PR DESCRIPTION
Closes issues #22 and #29:
- Telemetry limited to fixed width array for memory efficiency
- True impact time and location is determined, all states interpolated "backwards" to correct moment in time (i.e. when `linPosZ` <= 0)
- `fmt` library is used to replace streams for all CPP file I/O
- `serial` Monte Carlo mode introduced (no multiprocessing)
- Three (3) different output modes created: `text` (CSV), `binary` (NPY), or `none` (stats only)
  - Currently, binary output not supported (yet)
- Metadata is now printed on output files for better tracking
- `std::map` replaced with `std::unordered_map` for runtime lookup performance gains