### PR TITLE
Fixing Failed CI Actions

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,6 @@ set(HDR "./model/model.h"
 set(DEP util_model
         gsl
         fmt
-        -static-libstdc++
         )
 
 pybind11_add_module(model MODULE ${SRC} ${HDR})

--- a/src/model/telem.cpp
+++ b/src/model/telem.cpp
@@ -74,7 +74,6 @@ void Telem::finalize()
 
     // Finalize telem output
     write_output();
-    std::fclose(telemFile);
 
     // Finalize stats output
     update_stats();
@@ -296,6 +295,11 @@ void Telem::interp_boundary(std::string targetField, double targetPoint)
 
     }
 
+}
+
+Telem::~Telem()
+{
+    std::fclose(telemFile);
 }
 
 //----------------------------------------------------------------------------//

--- a/src/model/telem.h
+++ b/src/model/telem.h
@@ -22,6 +22,7 @@ class Telem
     public:
 
         Telem(const std::string& telemModeIn,  const int& nPrecIn, const std::string& outputDirIn, const std::string& metaStrIn);
+        ~Telem();
 
         void init();
         void update(int iStep);

--- a/tools/pyinstaller_build.py
+++ b/tools/pyinstaller_build.py
@@ -15,22 +15,27 @@ import util_misc
 name       = "hpr-sim"
 workPath   = pathlib.Path("build/pyinstaller")
 distPath   = workPath / "dist"
-outputPath = distPath / "hpr-sim/output"
+outputPath = distPath / "hpr-sim" / "output"
 
 # Set import search paths
 paths = ["src/exec", "src/gui", "src/preproc", "src/postproc", "src/util"]
 
 # Set binary files and bundled locations: ("filePath", "location")
 
-if os.name == "posix":
+if os.name == "posix": # Linux build
+
+    # Bundle pybind11 module
     binaries = [("build/src/model.cpython-310-x86_64-linux-gnu.so", ".")]
-elif os.name == "nt":
+
+elif os.name == "nt": # Windows build
+
+    # Bundle pybind11 module
     binaries = [("build/src/model.cp310-win_amd64.pyd", ".")]
+
+    # Bundle libstdc++ from mingw64
     compilerPath = util_misc.get_cmake_cache("CMAKE_CXX_COMPILER")
     libPath      = pathlib.Path(compilerPath).parent / "libstdc++-6.dll"
     binaries    += [(libPath.resolve().as_posix(), ".")]
-
-print(libPath.resolve().as_posix())
 
 # Set data files and bundled locations: ("filePath", "location")
 data = [("build/CMakeCache.txt"        , "."), 
@@ -40,11 +45,14 @@ data = [("build/CMakeCache.txt"        , "."),
 # Excluded modules from bundle
 excludes = ["PySide2", "PySide6", "PyQt6"] # Using PyQt5; Qt bindings conflict with each other
 
+#------------------------------------------------------------------------------#
+
 # Gather PyInstaller arguments
 args = []
 
 args += [f"{name}.py"]
 args += ["--noconfirm"]
+
 args += ["--workpath"]
 args += [workPath.resolve().as_posix()]
 args += ["--distpath"]
@@ -69,6 +77,8 @@ for exclude in excludes:
 # Execute PyInstaller
 PyInstaller.__main__.run(args)
 
+#------------------------------------------------------------------------------#
+
 # Copy necessary directories
 outputPath.mkdir(parents=True, exist_ok=True)
-shutil.copytree("input", distPath / "hpr-sim/input")
+shutil.copytree("input", distPath / "hpr-sim" / "input")

--- a/tools/pyinstaller_build.py
+++ b/tools/pyinstaller_build.py
@@ -1,7 +1,15 @@
+import sys
 import os
 import shutil
 import pathlib
 import PyInstaller.__main__
+
+utilPath = pathlib.Path(__file__).parent.parent / "src" / "util"
+sys.path.append(utilPath.resolve().as_posix())
+
+import util_misc
+
+#------------------------------------------------------------------------------#
 
 # PyInstaller setup
 name       = "hpr-sim"
@@ -18,52 +26,49 @@ if os.name == "posix":
     binaries = [("build/src/model.cpython-310-x86_64-linux-gnu.so", ".")]
 elif os.name == "nt":
     binaries = [("build/src/model.cp310-win_amd64.pyd", ".")]
+    compilerPath = util_misc.get_cmake_cache("CMAKE_CXX_COMPILER")
+    libPath      = pathlib.Path(compilerPath).parent / "libstdc++-6.dll"
+    binaries    += [(libPath.resolve().as_posix(), ".")]
+
+print(libPath.resolve().as_posix())
 
 # Set data files and bundled locations: ("filePath", "location")
-datas = [("build/CMakeCache.txt"        , "."), 
-         ("src/preproc/config_input.yml", "."), 
-         ("src/util/config_unit.yml"    , ".")]
+data = [("build/CMakeCache.txt"        , "."), 
+        ("src/preproc/config_input.yml", "."), 
+        ("src/util/config_unit.yml"    , ".")]
 
 # Excluded modules from bundle
 excludes = ["PySide2", "PySide6", "PyQt6"] # Using PyQt5; Qt bindings conflict with each other
 
-# Execute PyInstaller commands
-PyInstaller.__main__.run([
-    f"{name}.py",
-    "--workpath",
-    workPath.resolve().as_posix(),
-    "--distpath",
-    distPath.resolve().as_posix(),
-    "--noconfirm",
-    "--paths",
-    paths[0],
-    "--paths",
-    paths[1],
-    "--paths",
-    paths[2],
-    "--paths",
-    paths[3],
-    "--paths",
-    paths[4],
-    "--add-binary",
-    f"{binaries[0][0]}:{binaries[0][1]}",
-    "--add-data",
-    f"{datas[0][0]}:{datas[0][1]}",
-    "--add-data",
-    f"{datas[1][0]}:{datas[1][1]}",
-    "--add-data",
-    f"{datas[2][0]}:{datas[2][1]}",
-    "--exclude-module",
-    f"{excludes[0]}",
-    "--exclude-module",
-    f"{excludes[1]}",
-    "--exclude-module",
-    f"{excludes[2]}",
-    "--hidden-import",
-    "scipy.special._special_ufuncs",
-    "--hidden-import",
-    "scipy._lib.array_api_compat.numpy.fft"
-])
+# Gather PyInstaller arguments
+args = []
 
+args += [f"{name}.py"]
+args += ["--noconfirm"]
+args += ["--workpath"]
+args += [workPath.resolve().as_posix()]
+args += ["--distpath"]
+args += [distPath.resolve().as_posix()]
+
+for path in paths:
+    args += ["--paths"]
+    args += [path]
+
+for binInfo in binaries:
+    args += ["--add-binary"]
+    args += [f"{binInfo[0]}:{binInfo[1]}"]
+
+for dataInfo in data:
+    args += ["--add-data"]
+    args += [f"{dataInfo[0]}:{dataInfo[1]}"]
+
+for exclude in excludes:
+    args += ["--exclude-module"]
+    args += [exclude]
+
+# Execute PyInstaller
+PyInstaller.__main__.run(args)
+
+# Copy necessary directories
 outputPath.mkdir(parents=True, exist_ok=True)
 shutil.copytree("input", distPath / "hpr-sim/input")

--- a/tools/pyinstaller_build.py
+++ b/tools/pyinstaller_build.py
@@ -22,12 +22,12 @@ paths = ["src/exec", "src/gui", "src/preproc", "src/postproc", "src/util"]
 
 # Set binary files and bundled locations: ("filePath", "location")
 
-if os.name == "posix": # Linux build
+if os.name == "posix":
 
     # Bundle pybind11 module
     binaries = [("build/src/model.cpython-310-x86_64-linux-gnu.so", ".")]
 
-elif os.name == "nt": # Windows build
+elif os.name == "nt":
 
     # Bundle pybind11 module
     binaries = [("build/src/model.cp310-win_amd64.pyd", ".")]
@@ -44,6 +44,13 @@ data = [("build/CMakeCache.txt"        , "."),
 
 # Excluded modules from bundle
 excludes = ["PySide2", "PySide6", "PyQt6"] # Using PyQt5; Qt bindings conflict with each other
+
+# Hidden imports to resolve python environment inconsistencies
+if os.name == "posix":
+    hiddenImports = ["scipy.special._special_ufuncs"        ,
+                     "scipy._lib.array_api_compat.numpy.fft"]
+elif os.name == "nt":
+    hiddenImports = []
 
 #------------------------------------------------------------------------------#
 
@@ -73,6 +80,10 @@ for dataInfo in data:
 for exclude in excludes:
     args += ["--exclude-module"]
     args += [exclude]
+
+for hidden in hiddenImports:
+    args += ["--hidden-import"]
+    args += [hidden]
 
 # Execute PyInstaller
 PyInstaller.__main__.run(args)


### PR DESCRIPTION
- Checks on Linux & Windows runners were failing due to static linking of `libstdc++`
- Removed static linking, and modified pyinstaller script to explicitly bundle `libstdc++` with distribution, taken from compiler's installation (on Windows only, i.e. lib taken from MINGW64 folder)
  - If `libstdc++` is not bundled on Windows, pyinstaller may pull it from other programs' installations (like Git Bash)
- Misc. improvements and cleanup for pyinstaller script
- Added explicit destructor for `Telem` class